### PR TITLE
Add half star symbol to BASE_SYMBOL_PATTERNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add interactive rating symbols to your notes that update with a click.
 
 | Symbol Type | Full | Empty | Half | Examples |
 |-------------|------|-------|------|----------|
-| Stars | ★ | ☆ |  | `★★★☆☆ (3/5)` Book rating |
+| Stars | ★ | ☆ | ⯪  | `★★⯪☆☆ (2.5/5)` Book rating |
 | Star Symbols | ✦ | ✧ |  | `✦✦✦✧✧ (3/5)` Stargazing |
 | Moon Phases | 🌕 | 🌑 | 🌗 | `🌕🌕🌗🌑🌑 (2.5/5)` Lunar observation |
 | Circles | ● | ○ | ◐ | `●●●○○○○○○○ 3/10` Movie review scale |

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,7 +24,7 @@ export const LOGGING_ENABLED = process.env.LOGGING_ENABLED === 'true';
 
 // Base symbol patterns (excluding user-configurable emojis)
 export const BASE_SYMBOL_PATTERNS: SymbolSet[] = [
-  { full: '★', empty: '☆', half: null },    // Symbols
+  { full: '★', empty: '☆', half: '⯪' },    // Symbols
   { full: '✦', empty: '✧', half: null },    // Star symbols
   { full: '🌕', empty: '🌑', half: '🌗' },   // Moon phases
   { full: '●', empty: '○', half: '◐' },     // Circles


### PR DESCRIPTION
Hi,

I would like to use the Unicode stars (`★` and `☆`) for my ratings, but I noticed the half star (`⯪`) is not registered in this plugin. Is there a technical reason for this? If not, please consider the pull request to add it to `BASE_SYMBOL_PATTERNS`.

Thank you!